### PR TITLE
Allow class name to be configurable by user post-creation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
   "__svc_name": "{{ cookiecutter.service_name | replace('assemblyline-service-', '') }}",
   "__repository": "assemblyline-service-{{ cookiecutter.__svc_name }}",
   "__pkg_name": "{{ cookiecutter.service_name | replace('-', '_') }}",
-  "__class_name": "{{ cookiecutter.__pkg_name | replace ('_', ' ') | title | replace(' ', '') }}",
+  "class_name": "{{ cookiecutter.__pkg_name | replace ('_', ' ') | title | replace(' ', '') }}",
   "short_description": "This Assemblyline service is amazing and does amazing things.",
   "short_description_fr": "",
   "stage": ["FILTER", "EXTRACT", "CORE", "SECONDARY", "POST", "REVIEW"],

--- a/{{ cookiecutter.__repository }}/.vscode/launch.json
+++ b/{{ cookiecutter.__repository }}/.vscode/launch.json
@@ -12,7 +12,7 @@
             "cwd": "${workspaceFolder}",
             "args": [
                 "-d",
-                "{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__class_name }}",
+                "{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__pkg_name }}.{{ cookiecutter.class_name }}",
                 "${file}"
             ],
             "justMyCode": false,

--- a/{{ cookiecutter.__repository }}/Dockerfile
+++ b/{{ cookiecutter.__repository }}/Dockerfile
@@ -2,7 +2,7 @@ ARG branch=latest
 FROM cccs/assemblyline-v4-service-base:$branch
 
 # Python path to the service class from your service directory
-ENV SERVICE_PATH {{ cookiecutter.__pkg_name }}.{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__class_name }}
+ENV SERVICE_PATH {{ cookiecutter.__pkg_name }}.{{ cookiecutter.__pkg_name }}.{{ cookiecutter.class_name }}
 
 # Install apt dependencies
 USER root

--- a/{{ cookiecutter.__repository }}/README.md
+++ b/{{ cookiecutter.__repository }}/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/github/license/{{ cookiecutter.org_name_full }}/{{ cookiecutter.__repository }})](./LICENSE)
 {% endif -%}
 
-# {{ cookiecutter.__class_name }} Service
+# {{ cookiecutter.class_name }} Service
 
 {{ cookiecutter.short_description }}
 
@@ -31,7 +31,7 @@ This is an Assemblyline service. It is designed to run as part of the Assemblyli
 If you would like to test this service locally, you can run the Docker image directly from the a shell:
 
     docker run \
-        --name {{ cookiecutter.__class_name }} \
+        --name {{ cookiecutter.class_name }} \
         --env SERVICE_API_HOST=http://`ip addr show docker0 | grep "inet " | awk '{print $2}' | cut -f1 -d"/"`:5003 \
         --network=host \
         {{ cookiecutter.org_name_short }}/{{ cookiecutter.__repository }}
@@ -45,7 +45,7 @@ General Assemblyline documentation can be found at: https://cybercentrecanada.gi
 
 {% if cookiecutter.short_description_fr != "" -%}
 
-# Service {{ cookiecutter.__class_name }}
+# Service {{ cookiecutter.class_name }}
 
 {{ cookiecutter.short_description_fr }}
 
@@ -69,7 +69,7 @@ Ce service est spécialement optimisé pour fonctionner dans le cadre d'un dépl
 Si vous souhaitez tester ce service localement, vous pouvez exécuter l'image Docker directement à partir d'un terminal:
 
     docker run \
-        --name {{ cookiecutter.__class_name }} \
+        --name {{ cookiecutter.class_name }} \
         --env SERVICE_API_HOST=http://`ip addr show docker0 | grep "inet " | awk '{print $2}' | cut -f1 -d"/"`:5003 \
         --network=host \
         {{ cookiecutter.org_name_short }}/{{ cookiecutter.__repository }}

--- a/{{ cookiecutter.__repository }}/service_manifest.yml
+++ b/{{ cookiecutter.__repository }}/service_manifest.yml
@@ -1,4 +1,4 @@
-name: {{ cookiecutter.__class_name }}
+name: {{ cookiecutter.class_name }}
 version: $SERVICE_TAG
 description: {{ cookiecutter.short_description }}
 

--- a/{{ cookiecutter.__repository }}/tests/test_{{ cookiecutter.__pkg_name }}.py
+++ b/{{ cookiecutter.__repository }}/tests/test_{{ cookiecutter.__pkg_name }}.py
@@ -13,7 +13,7 @@ RESULTS_FOLDER = os.path.join(os.path.dirname(__file__), "results")
 SAMPLES_FOLDER = os.path.join(os.path.dirname(__file__), "samples")
 
 # Initialize test helper
-service_class = load_module_by_path("{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__class_name }}", os.path.join(os.path.dirname(__file__), ".."))
+service_class = load_module_by_path("{{ cookiecutter.__pkg_name }}.{{ cookiecutter.__pkg_name }}.{{ cookiecutter.class_name }}", os.path.join(os.path.dirname(__file__), ".."))
 th = TestHelper(service_class, RESULTS_FOLDER, SAMPLES_FOLDER)
 
 

--- a/{{ cookiecutter.__repository }}/{{ cookiecutter.__pkg_name }}/{{ cookiecutter.__pkg_name }}.py
+++ b/{{ cookiecutter.__repository }}/{{ cookiecutter.__pkg_name }}/{{ cookiecutter.__pkg_name }}.py
@@ -6,7 +6,7 @@ from assemblyline_v4_service.common.request import ServiceRequest
 from assemblyline_v4_service.common.result import Result
 
 
-class {{ cookiecutter.__class_name }}(ServiceBase):
+class {{ cookiecutter.class_name }}(ServiceBase):
     """{{ cookiecutter.short_description }}"""
 
     def execute(self, request: ServiceRequest):


### PR DESCRIPTION
ie. cases of Emlparser (generated by the template) vs EmlParser (user-preferred name of the class/service), this change should ensure `cruft update`s don't revert back to what the template created.